### PR TITLE
Introduce math expression data constructor

### DIFF
--- a/src/Constructors.hs
+++ b/src/Constructors.hs
@@ -19,11 +19,12 @@ module Constructors
     , bold
     , italic
     , strikeThrough
-    , customStyle
+    , mathExpr
+    , codeNotation
     -- * For creating custom style
     , styleData
+    , customStyle
     -- * Segment
-    , codeNotation
     , hashtag
     , link
     , text
@@ -113,9 +114,13 @@ strikeThrough = ITEM StrikeThrough
 customStyle :: StyleData -> [Segment] -> InlineBlock
 customStyle sData = ITEM (CustomStyle sData)
 
--- | Creates 'CODE_NOTATION' segment with given 'Text'
+-- | Creates 'CODE_NOTATION' inline block with given 'Text'
 codeNotation :: Text -> InlineBlock
 codeNotation = CODE_NOTATION
+
+-- | Creates 'CODE_NOTATION' inline block with given 'Text'
+mathExpr :: Text -> InlineBlock
+mathExpr = MATH_EXPRESSION
 
 --------------------------------------------------------------------------------
 -- Segment

--- a/src/Parser/ScrapText.hs
+++ b/src/Parser/ScrapText.hs
@@ -68,6 +68,7 @@ scrapTextParser = ScrapText <$> manyTill inlineBlockParser eof
 inlineBlockParser :: Parser InlineBlock
 inlineBlockParser =
         try codeNotationParser
+    <|> try mathExpressionParser
     <|> try boldParser
     <|> try styledTextParser
     <|> try noStyleParser
@@ -234,6 +235,11 @@ codeNotationParser = do
     content <- between (char '`') (char '`') $ many1 (noneOf "`")
     return $ CODE_NOTATION $ fromString content
 
+-- | Parser for 'MATH_EXPRESSION'
+mathExpressionParser :: Parser InlineBlock
+mathExpressionParser = do
+    content <- between (string "[$") (char ']') $ many1 (noneOf "]")
+    return $ MATH_EXPRESSION $ fromString content
 --------------------------------------------------------------------------------
 -- Needs attention
 --------------------------------------------------------------------------------

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -71,6 +71,7 @@ renderText (ScrapText inlines) =
 renderScrapText :: InlineBlock -> Text
 renderScrapText (ITEM style content)    = renderWithStyle style content
 renderScrapText (CODE_NOTATION content) = "`" <> content <> "`"
+renderScrapText (MATH_EXPRESSION expr)  = "[$" <> expr <> "]"
 
 -- | Render given 'Content' to 'Text'
 renderContent :: [Segment] -> Text

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -214,10 +214,10 @@ unverbose (Scrapbox blocks) = Scrapbox $ map unVerboseBlock blocks
 -- | Concatinate 'ITEM' with same style
 concatInline :: [InlineBlock] -> [InlineBlock]
 concatInline []       = []
-concatInline [inline]    = [inline]
+concatInline [inline] = [inline]
 concatInline (c1@(ITEM style1 inline1):c2@(ITEM style2 inline2):rest)
     | style1 == style2 = concatInline (ITEM style1 (inline1 <> inline2) : rest)
-    | otherwise        = c1 : c2 : concatInline rest
+    | otherwise        = c1 : concatInline (c2:rest)
 concatInline (a : c@(ITEM _ _) : rest) = a : concatInline (c:rest)
 concatInline (a : b : rest)            = a : b : concatInline rest
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -32,6 +32,7 @@ module Types
     , isBulletPoint
     , isCodeBlock
     , isCodeNotation
+    , isMathExpr
     , isHeader
     , isLink
     , isParagraph
@@ -270,10 +271,15 @@ isLink :: Segment -> Bool
 isLink (LINK _ _) = True
 isLink _          = False
 
--- | Checks whether given 'Segment' is 'CODE_NOTATION'
+-- | Checks whether given 'InlineBlock' is 'CODE_NOTATION'
 isCodeNotation :: InlineBlock -> Bool
 isCodeNotation (CODE_NOTATION _) = True
 isCodeNotation _                 = False
+
+-- | Checks whether given 'Inline' is 'MATH_EXPRESSION'
+isMathExpr :: InlineBlock -> Bool
+isMathExpr (MATH_EXPRESSION _) = True
+isMathExpr _                   = False
 
 -- | Checks whether given 'Segment' is 'TEXT'
 isSimpleText :: Segment -> Bool

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -126,7 +126,7 @@ data InlineBlock
     -- ^ ITEM are blocks which can have styles
     | CODE_NOTATION !Text
     -- ^ Code notation
-    -- | MATH_EXPRESSION !TEXT (TODO)
+    | MATH_EXPRESSION !Text
     deriving (Eq, Show, Generic, Read, Ord)
 
 -- | Segment
@@ -218,10 +218,8 @@ concatInline [inline]    = [inline]
 concatInline (c1@(ITEM style1 inline1):c2@(ITEM style2 inline2):rest)
     | style1 == style2 = concatInline (ITEM style1 (inline1 <> inline2) : rest)
     | otherwise        = c1 : c2 : concatInline rest
-concatInline (CODE_NOTATION txt : rest) =
-    CODE_NOTATION txt : concatInline rest
-concatInline (c1@(ITEM _ _) : c2@(CODE_NOTATION _) : rest) =
-    c1 : c2 : concatInline rest
+concatInline (a : c@(ITEM _ _) : rest) = a : concatInline (c:rest)
+concatInline (a : b : rest)            = a : b : concatInline rest
 
 -- | Concatenate 'ScrapText'
 -- This could be Semigroup, but definitely not Monoid (there's no mempty)

--- a/test/ParserTest.hs
+++ b/test/ParserTest.hs
@@ -575,6 +575,7 @@ propParseAsExpected example expected parser = monadicIO $ eitherM
     (\parsedContent -> assert $ parsedContent == expected)
     (return $ parser example)
 
+-- | Math expression syntax
 newtype MathExpr = MathExpr Text
     deriving Show
 
@@ -585,6 +586,7 @@ instance ScrapboxSyntax MathExpr where
     render (MathExpr txt)     = "[$" <> txt <> "]"
     getContent (MathExpr txt) = txt
 
+-- | Type class used to render/get content of given syntax
 class ScrapboxSyntax a where
     render     :: a -> Text
     getContent :: a -> Text
@@ -600,6 +602,7 @@ genRandomText :: Gen Text
 genRandomText = fmap fromString <$> listOf1
     $ elements (['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'])
 
+-- | Check parsed
 checkParsed :: (ScrapboxSyntax syntax)
             => syntax
             -- ^ Syntax that we want to test on
@@ -615,6 +618,7 @@ checkParsed syntax parser getter pre = property $ either
     (maybe False pre . getter)
     (parser $ T.unpack $ render syntax)
 
+-- | Test case to check whether the parsed thing still preserves its content
 checkContent :: (ScrapboxSyntax syntax)
              => syntax
              -- ^ Syntax that we want to test on


### PR DESCRIPTION
This PR introduces math expression data constructor used in scrapbox `[$ expr]` as well as its parser