### PR TITLE
Implement inline parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,5 @@ The library is well-tested including round-trip test which tests whether given a
 AST can be rendered, then parsed as original AST.
 
 ## Known issue
-- When parsing commonmark, it cannot parse strikethrough text (~~Like this~~)
 - When parsing commonmark, it cannot parse `CUSTOM_INLINE`, `CUSTOM_BLOCK`, `THEMATIC_BLOCK` properly
-- When parsing commonmark, it cannot render relative link correctly.
 - When parsing scrapbox, some of the inline styles cannot be parsed correctly
-- When using `scrapboxToCommonmark`, it will not render the `THUMBNAIL` correctly. This is due to the library
-missing the url parsing logic therefore the parser cannot know whether the given url is an image url
-so it'll render as an simple url. Fixing this issue is the highest priority.

--- a/scrapbox.cabal
+++ b/scrapbox.cabal
@@ -29,9 +29,10 @@ library
                        Data.Scrapbox.Parser.Scrapbox
                        Data.Scrapbox.Parser.Scrapbox.Item
                        Data.Scrapbox.Parser.Scrapbox.ScrapText
-                       Data.Scrapbox.Parser.Scrapbox.Utils
+                       Data.Scrapbox.Parser.Utils
                        Data.Scrapbox.Parser.Commonmark
                        Data.Scrapbox.Parser.Commonmark.TableParser
+                       Data.Scrapbox.Parser.Commonmark.ParagraphParser
                        Data.Scrapbox.Render.Scrapbox
                        Data.Scrapbox.Render.Commonmark
                        Data.Scrapbox.Utils

--- a/src/Data/Scrapbox/Internal.hs
+++ b/src/Data/Scrapbox/Internal.hs
@@ -10,6 +10,7 @@ module Data.Scrapbox.Internal
     , runScrapTextParser
     , runItemParser
     , runScrapboxParser
+    , runParagraphParser
     -- * Helper functions
     , concatInline
     , concatSegment
@@ -36,6 +37,7 @@ module Data.Scrapbox.Internal
     , isNoStyle
     ) where
 
+import           Data.Scrapbox.Parser.Commonmark.ParagraphParser (runParagraphParser)
 import           Data.Scrapbox.Parser.Scrapbox (runScrapboxParser)
 import           Data.Scrapbox.Parser.Scrapbox.Item (runItemParser)
 import           Data.Scrapbox.Parser.Scrapbox.ScrapText (runScrapTextParser)

--- a/src/Data/Scrapbox/Parser/Commonmark.hs
+++ b/src/Data/Scrapbox/Parser/Commonmark.hs
@@ -31,8 +31,8 @@ import           Data.Scrapbox.Types as S (Block (..), InlineBlock (..),
                                            Scrapbox (..), Segment (..),
                                            concatInline, concatScrapText)
 
-import           Data.Scrapbox.Parser.Commonmark.TableParser (parseTable)
 import           Data.Scrapbox.Parser.Commonmark.ParagraphParser (toInlineBlocks)
+import           Data.Scrapbox.Parser.Commonmark.TableParser (parseTable)
 
 --------------------------------------------------------------------------------
 -- Exposed interface
@@ -112,7 +112,7 @@ toBlocks (Node _ nodeType contents) = case nodeType of
     C.HEADING headingNum       -> [toHeading headingNum contents]
     C.EMPH                     -> [paragraph [italic (concatMap toSegments contents)]]
     C.STRONG                   -> [paragraph [bold (concatMap toSegments contents)]]
-    C.TEXT textContent         -> [paragraph (toInlineBlocks textContent)]
+    C.TEXT textContent         -> [paragraph $ toInlineBlocks textContent]
     C.CODE codeContent         -> [paragraph [codeNotation codeContent]]
     C.CODE_BLOCK codeInfo code -> [toCodeBlock codeInfo (T.lines code)]
     C.LIST _                   -> [toBulletPoint contents]

--- a/src/Data/Scrapbox/Parser/Commonmark.hs
+++ b/src/Data/Scrapbox/Parser/Commonmark.hs
@@ -32,6 +32,7 @@ import           Data.Scrapbox.Types as S (Block (..), InlineBlock (..),
                                            concatInline, concatScrapText)
 
 import           Data.Scrapbox.Parser.Commonmark.TableParser (parseTable)
+import           Data.Scrapbox.Parser.Commonmark.ParagraphParser (toInlineBlocks)
 
 --------------------------------------------------------------------------------
 -- Exposed interface
@@ -111,7 +112,7 @@ toBlocks (Node _ nodeType contents) = case nodeType of
     C.HEADING headingNum       -> [toHeading headingNum contents]
     C.EMPH                     -> [paragraph [italic (concatMap toSegments contents)]]
     C.STRONG                   -> [paragraph [bold (concatMap toSegments contents)]]
-    C.TEXT textContent         -> [paragraph [noStyle [text textContent]]]
+    C.TEXT textContent         -> [paragraph (toInlineBlocks textContent)]
     C.CODE codeContent         -> [paragraph [codeNotation codeContent]]
     C.CODE_BLOCK codeInfo code -> [toCodeBlock codeInfo (T.lines code)]
     C.LIST _                   -> [toBulletPoint contents]

--- a/src/Data/Scrapbox/Parser/Commonmark/ParagraphParser.hs
+++ b/src/Data/Scrapbox/Parser/Commonmark/ParagraphParser.hs
@@ -51,6 +51,7 @@ noStyleParser = ITEM NoStyle <$> extractNonStyledText
             <|> try (string "_")
             <|> try (string "*")
             <|> try (string "~~")
+            -- This is needed to avoid inifinite loop
             <|> try (string "~")
             <|> try (many1 (noneOf syntaxSymbols))
             )

--- a/src/Data/Scrapbox/Parser/Commonmark/ParagraphParser.hs
+++ b/src/Data/Scrapbox/Parser/Commonmark/ParagraphParser.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Data.Scrapbox.Parser.Commonmark.ParagraphParser
+    ( toInlineBlocks
+    ) where
+
+
+import           RIO hiding (many, try, (<|>))
+
+import           Data.Scrapbox.Parser.Utils (lookAheadMaybe)
+import qualified RIO.Text as T
+import           Text.ParserCombinators.Parsec (Parser, anyChar, eof, many,
+                                                many1, manyTill, noneOf, parse,
+                                                string, try, (<?>), (<|>))
+
+import           Data.Scrapbox.Types (InlineBlock (..), Segment (..),
+                                      Style (..))
+
+strongParser :: Parser InlineBlock
+strongParser = do
+    str <- try (string "**") <|> string "__"
+    text <- manyTill anyChar (try $ string str)
+    return $ ITEM Bold [TEXT (fromString text)]
+
+emphParser :: Parser InlineBlock
+emphParser = do
+    str  <- try (string "*") <|> string "_"
+    text <- many1 $ noneOf str
+    _    <- string str
+    return $ ITEM Italic [TEXT (fromString text)]
+
+strikeThroughParser :: Parser InlineBlock
+strikeThroughParser = do
+    _    <- string "~~"
+    text <- manyTill anyChar (try $ string "~~")
+    return $ ITEM StrikeThrough [TEXT (fromString text)]
+
+-- | Parser for non-styled text
+noStyleParser :: Parser InlineBlock
+noStyleParser = ITEM NoStyle <$> extractNonStyledText
+  where
+
+    extractNonStyledText :: Parser [Segment]
+    extractNonStyledText = go mempty
+
+    go :: String -> Parser [Segment]
+    go content = do
+        someChar <- lookAheadMaybe
+            (   try (string "__")
+            <|> try (string "**")
+            <|> try (string "_")
+            <|> try (string "*")
+            <|> try (string "~~")
+            <|> try (many1 (noneOf syntaxSymbols))
+            )
+        case someChar of
+            Nothing   -> return [TEXT (fromString content)]
+            -- Check if ahead content can be parsed as strong
+            Just "**" -> checkWith "*" strongParser content
+            Just "__" -> checkWith "_" strongParser content
+            -- Check if ahead content can be parsed as emph
+            Just "*"  -> checkWith "*" emphParser content
+            Just "_"  -> checkWith "_" emphParser content
+            -- Check if ahead content can be parsed as strikethrough
+            Just "~~"  -> checkWith "~~" strikeThroughParser content
+            -- For everything else, consume until syntax
+            Just _ -> do
+                rest <- many1 $ noneOf syntaxSymbols
+                go $ content <> rest
+
+    -- Run parser on ahead content to see if it can be parsed, if not, consume the text
+    checkWith :: String -> Parser a -> String -> Parser [Segment]
+    checkWith symbolStr parser content = do
+        canBeParsed <- isJust <$> lookAheadMaybe parser
+        if canBeParsed
+            then return [TEXT (fromString content)]
+            else continue symbolStr content
+
+    continue :: String -> String -> Parser [Segment]
+    continue symbol curr = do
+        someSymbol <- string symbol
+        rest       <- many (noneOf syntaxSymbols)
+        go $ curr <> someSymbol <> rest
+
+    syntaxSymbols :: String
+    syntaxSymbols = "_*~"
+
+toInlineBlocks :: Text -> [InlineBlock]
+toInlineBlocks text =
+    either
+        (const [ITEM NoStyle [TEXT text]])
+        id
+        (parse parser "Paragraph parser" (T.unpack text))
+  where
+    parser :: Parser [InlineBlock]
+    parser = manyTill (
+            try strikeThroughParser
+        <|> try strongParser
+        <|> try emphParser
+        <|> try noStyleParser
+        <?> "Cannot parse given paragraph"
+        ) (try eof)

--- a/src/Data/Scrapbox/Parser/Commonmark/ParagraphParser.hs
+++ b/src/Data/Scrapbox/Parser/Commonmark/ParagraphParser.hs
@@ -7,12 +7,12 @@ module Data.Scrapbox.Parser.Commonmark.ParagraphParser
 
 import           RIO hiding (many, try, (<|>))
 
-import           Data.Scrapbox.Parser.Utils (lookAheadMaybe)
 import qualified RIO.Text as T
 import           Text.ParserCombinators.Parsec (Parser, anyChar, eof, many,
                                                 many1, manyTill, noneOf, parse,
                                                 string, try, (<?>), (<|>))
 
+import           Data.Scrapbox.Parser.Utils (lookAheadMaybe)
 import           Data.Scrapbox.Types (InlineBlock (..), Segment (..),
                                       Style (..))
 

--- a/src/Data/Scrapbox/Parser/Commonmark/ParagraphParser.hs
+++ b/src/Data/Scrapbox/Parser/Commonmark/ParagraphParser.hs
@@ -51,6 +51,7 @@ noStyleParser = ITEM NoStyle <$> extractNonStyledText
             <|> try (string "_")
             <|> try (string "*")
             <|> try (string "~~")
+            <|> try (string "~")
             <|> try (many1 (noneOf syntaxSymbols))
             )
         case someChar of
@@ -62,10 +63,14 @@ noStyleParser = ITEM NoStyle <$> extractNonStyledText
             Just "*"  -> checkWith "*" emphParser content
             Just "_"  -> checkWith "_" emphParser content
             -- Check if ahead content can be parsed as strikethrough
-            Just "~~"  -> checkWith "~~" strikeThroughParser content
+            Just "~~" -> checkWith "~~" strikeThroughParser content
             -- For everything else, consume until syntax
+            Just "~"  -> do
+                char <- anyChar
+                rest <- many $ noneOf syntaxSymbols
+                go $ content <> [char] <> rest
             Just _ -> do
-                rest <- many1 $ noneOf syntaxSymbols
+                rest <- many $ noneOf syntaxSymbols
                 go $ content <> rest
 
     -- Run parser on ahead content to see if it can be parsed, if not, consume the text

--- a/src/Data/Scrapbox/Parser/Scrapbox/Item.hs
+++ b/src/Data/Scrapbox/Parser/Scrapbox/Item.hs
@@ -19,7 +19,7 @@ import           Text.ParserCombinators.Parsec (ParseError, Parser, anyChar,
                                                 sepBy1, space, try, unexpected,
                                                 (<?>), (<|>))
 
-import           Data.Scrapbox.Parser.Scrapbox.Utils (lookAheadMaybe)
+import           Data.Scrapbox.Parser.Utils (lookAheadMaybe)
 import           Data.Scrapbox.Types (Segment (..), Url (..))
 
 --------------------------------------------------------------------------------

--- a/src/Data/Scrapbox/Parser/Utils.hs
+++ b/src/Data/Scrapbox/Parser/Utils.hs
@@ -1,7 +1,7 @@
 {-| Utility function used within parser modules
 -}
 
-module Data.Scrapbox.Parser.Scrapbox.Utils
+module Data.Scrapbox.Parser.Utils
     ( lookAheadMaybe
     ) where
 

--- a/src/Data/Scrapbox/Render/Commonmark.hs
+++ b/src/Data/Scrapbox/Render/Commonmark.hs
@@ -175,7 +175,7 @@ renderTable (TableName name) (TableContent contents) =
         return $ [renderColumn headColumn] <> [middle headColumnNums] <> map renderColumn rest
 
     renderColumn :: [Text] -> Text
-    renderColumn items = "|" <> foldr (\item acc -> item <> "|" <> acc) mempty items
+    renderColumn items = "| " <> foldr (\item acc -> item <> " | " <> acc) mempty items
 
     middle :: [Int] -> Text
-    middle = foldl' (\acc num -> acc <> T.replicate num "-" <> "|") "|"
+    middle = foldl' (\acc num -> acc <> T.replicate (num + 2) "-" <> "|") "|"

--- a/test/TestCommonMark/Commonmark.hs
+++ b/test/TestCommonMark/Commonmark.hs
@@ -10,7 +10,6 @@ module TestCommonMark.Commonmark
 import           RIO hiding (assert)
 import           Test.Hspec (Spec, describe)
 import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
-import           Test.QuickCheck (PrintableString (..))
 import           Test.QuickCheck.Monadic (assert, monadicIO)
 
 import           TestCommonMark.Blocks (blockSpec)
@@ -18,7 +17,7 @@ import           TestCommonMark.Segments (segmentSpec)
 import           TestCommonMark.Styles (styleSpec)
 
 import           Data.Scrapbox.Internal (runParagraphParser)
-import           Utils (NonEmptyPrintableString (..), whenRight)
+import           Utils (NonEmptyPrintableString (..), whenRight, shouldParseSpec)
 
 commonmarkSpec :: Spec
 commonmarkSpec = describe "CommonMark parser" $ modifyMaxSuccess (const 200) $ do
@@ -30,9 +29,7 @@ commonmarkSpec = describe "CommonMark parser" $ modifyMaxSuccess (const 200) $ d
 -- | Test case on @runParagraphParser@
 paragraphParserSpec :: Spec
 paragraphParserSpec = describe "runParagraphParser" $ modifyMaxSuccess (const 5000) $ do
-    prop "should not cause infinite loop" $
-        \(someText :: PrintableString) ->
-            isRight $ runParagraphParser $ getPrintableString someText
+    shouldParseSpec runParagraphParser
 
     prop "should return non-empty list of blocks if the given string is non-empty" $
         \(someText :: NonEmptyPrintableString) -> monadicIO $ do

--- a/test/TestCommonMark/Commonmark.hs
+++ b/test/TestCommonMark/Commonmark.hs
@@ -1,19 +1,43 @@
 {-| Test suites for commonmark parser
 -}
 
-module TestCommonMark.Commonmark where
+{-# LANGUAGE ScopedTypeVariables #-}
 
-import           RIO
-import           Test.Hspec
-import           Test.Hspec.QuickCheck
+module TestCommonMark.Commonmark
+    ( commonmarkSpec
+    ) where
+
+import           RIO hiding (assert)
+import           Test.Hspec (Spec, describe)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import           Test.QuickCheck (PrintableString (..))
+import           Test.QuickCheck.Monadic (assert, monadicIO)
 
 import           TestCommonMark.Blocks (blockSpec)
 import           TestCommonMark.Segments (segmentSpec)
 import           TestCommonMark.Styles (styleSpec)
 
+import           Data.Scrapbox.Internal (runParagraphParser)
+import           Utils (NonEmptyPrintableString (..), whenRight)
 
 commonmarkSpec :: Spec
 commonmarkSpec = describe "CommonMark parser" $ modifyMaxSuccess (const 200) $ do
     blockSpec
     segmentSpec
     styleSpec
+    paragraphParserSpec
+
+-- | Test case on @runParagraphParser@
+paragraphParserSpec :: Spec
+paragraphParserSpec = describe "runParagraphParser" $ modifyMaxSuccess (const 5000) $ do
+    prop "should not cause infinite loop" $
+        \(someText :: PrintableString) ->
+            isRight $ runParagraphParser $ getPrintableString someText
+
+    prop "should return non-empty list of blocks if the given string is non-empty" $
+        \(someText :: NonEmptyPrintableString) -> monadicIO $ do
+            let eParseredText = runParagraphParser $ getNonEmptyPrintableString someText
+
+            assert $ isRight eParseredText
+            whenRight eParseredText $ \inlines ->
+                assert $ not $ null inlines

--- a/test/TestScrapboxParser/Inline.hs
+++ b/test/TestScrapboxParser/Inline.hs
@@ -19,12 +19,11 @@ import           Test.QuickCheck.Monadic (assert, monadicIO)
 import           Data.Scrapbox (Segment (..), Url (..))
 import           Data.Scrapbox.Internal (isHashTag, isLink, isText,
                                          runItemParser)
-import           TestScrapboxParser.Utils (NonEmptyPrintableString (..),
-                                           ScrapboxSyntax (..), checkContent,
-                                           checkParsed, propParseAsExpected,
-                                           shouldParseSpec)
-import           Utils (genMaybe, genPrintableText, genPrintableUrl, genText,
-                        whenRight)
+import           TestScrapboxParser.Utils (ScrapboxSyntax (..), checkContent,
+                                           checkParsed, propParseAsExpected)
+import           Utils (NonEmptyPrintableString (..), genMaybe,
+                        genPrintableText, genPrintableUrl, genText,
+                        shouldParseSpec, whenRight)
 
 -- | Spec for inline text parser
 inlineParserSpec :: Spec

--- a/test/TestScrapboxParser/ScrapText.hs
+++ b/test/TestScrapboxParser/ScrapText.hs
@@ -27,11 +27,10 @@ import           Data.Scrapbox.Internal (concatSegment, isBold, isCodeNotation,
                                          isItalic, isMathExpr, isNoStyle,
                                          isStrikeThrough, renderSegments,
                                          runScrapTextParser)
-import           TestScrapboxParser.Utils (NonEmptyPrintableString (..),
-                                           ScrapboxSyntax (..), checkContent,
-                                           checkParsed, propParseAsExpected,
-                                           shouldParseSpec)
-import           Utils (genPrintableText, whenRight)
+import           TestScrapboxParser.Utils (ScrapboxSyntax (..), checkContent,
+                                           checkParsed, propParseAsExpected)
+import           Utils (NonEmptyPrintableString (..), genPrintableText,
+                        shouldParseSpec, whenRight)
 
 -- | Test spec for scrap text parser
 scrapTextParserSpec :: Spec

--- a/test/TestScrapboxParser/Scrapbox.hs
+++ b/test/TestScrapboxParser/Scrapbox.hs
@@ -21,9 +21,9 @@ import           Data.Scrapbox (Block (..), CodeName (..), CodeSnippet (..),
                                 Style (..), TableContent (..), TableName (..),
                                 Url (..), renderToScrapbox)
 import           Data.Scrapbox.Internal (runScrapboxParser)
-import           TestScrapboxParser.Utils (NonEmptyPrintableString (..),
-                                           propParseAsExpected, shouldParseSpec)
-import           Utils (whenRight)
+import           TestScrapboxParser.Utils (propParseAsExpected)
+import           Utils (NonEmptyPrintableString (..), shouldParseSpec,
+                        whenRight)
 --------------------------------------------------------------------------------
 -- Scrapbox parser
 --------------------------------------------------------------------------------

--- a/test/TestScrapboxParser/Utils.hs
+++ b/test/TestScrapboxParser/Utils.hs
@@ -5,10 +5,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module TestScrapboxParser.Utils
-    ( NonEmptyPrintableString(..)
-    , ScrapboxSyntax(..)
+    ( ScrapboxSyntax(..)
     , propParseAsExpected
-    , shouldParseSpec
     , checkContent
     , checkParsed
     ) where
@@ -16,32 +14,13 @@ module TestScrapboxParser.Utils
 import           RIO hiding (assert)
 
 import qualified RIO.Text as T
-import           Test.Hspec (Spec)
-import           Test.Hspec.QuickCheck (prop)
-import           Test.QuickCheck (Arbitrary (..), PrintableString (..),
-                                  Property, Testable (..),
-                                  arbitraryPrintableChar, listOf1)
+import           Test.QuickCheck (Property, Testable (..))
 import           Test.QuickCheck.Monadic (assert, monadicIO)
 import           Text.Parsec (ParseError)
 
 --------------------------------------------------------------------------------
 -- Helper functions
 --------------------------------------------------------------------------------
-
--- | Non-empty version of 'PrintableString'
-newtype NonEmptyPrintableString =  NonEmptyPrintableString
-    { getNonEmptyPrintableString :: String
-    } deriving Show
-
-instance Arbitrary NonEmptyPrintableString where
-    arbitrary = NonEmptyPrintableString <$> listOf1 arbitraryPrintableChar
-
--- | General testing spec for parser
-shouldParseSpec :: (String -> Either ParseError a) -> Spec
-shouldParseSpec parser =
-        prop "should be able to parse any text without failing or cause infinite loop" $
-            \(someText :: PrintableString) ->
-                isRight $ parser $ getPrintableString someText
 
 -- | General unit testing to see the parser can parse given data as expected
 propParseAsExpected :: (Eq parsed)


### PR DESCRIPTION
This PR introduces parser for commonmark.
Since `CMark` ignores syntax with certain condition.
strong, emph with no spaces: hello**hello**me
 strikethrough: ~~strike~~